### PR TITLE
Fix target value / date for geolocation diversity

### DIFF
--- a/_data/metrics.yml
+++ b/_data/metrics.yml
@@ -113,8 +113,8 @@
   default_value: 50.21
   danger_value: 33
   goal_value: 66
-  target_value: Jul 2022
-  target_date: 
+  target_value: 50
+  target_date: Jul 2022
   influence: 1
   data_sources: 
     - nodewatch-geolocation


### PR DESCRIPTION
Target value for geolocation was missing and was filled with the target date instead leading to broken display value on the app (see screenshot).

This PR fixes that, assuming a target value of 50%. (Please correct me if this assumption is wrong)

<img width="528" alt="image" src="https://user-images.githubusercontent.com/15629702/172742981-85d8605a-039b-448d-8025-21de95defa1c.png">
