### PR TITLE
Fix broken discord link

### DIFF
--- a/about.md
+++ b/about.md
@@ -15,7 +15,7 @@ The purpose of Project Sunshine is to identify centralization vectors, determine
 
 ## Get Involved
 
-Project Sunshine welcomes contributors! [Join us on Discord to collaborate](https://discord.gg/zE8guNfG49).
+Project Sunshine welcomes contributors! [Join us on Discord to collaborate](https://discord.gg/jeDvQc2rSX).
 
 
 <!-- 
@@ -26,6 +26,6 @@ The purpose of Project Sunshine is to identify centralization vectors, determine
 
 ### Get Involved
 
-Project Sunshine welcomes contributors! [Join us on Discord to collaborate](https://discord.gg/zE8guNfG49).
+Project Sunshine welcomes contributors! [Join us on Discord to collaborate](https://discord.gg/jeDvQc2rSX).
 
  -->


### PR DESCRIPTION
The discord link on the about page is broken. 
I fixed this by copy pasting the working link from the readme to the about page.