### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Bringing the light of decentralization to the darkness of centraliztion: a site 
 |[Join Discord](https://discord.gg/jeDvQc2rSX)|
 |:---:|
 
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/etheralpha/project-sunshine/badge)](https://www.gitpoap.io/gh/etheralpha/project-sunshine)
+
 **Table of Contents**
 - [Intro](#intro)
 	- [Introduction & Purpose](#introduction--purpose)


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie